### PR TITLE
feat: integrate Turnstile for bot prevention

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,8 +12,9 @@
   <link rel="stylesheet" href="pico.blue.min.css" />
   <link rel="stylesheet" href="style.css" />
   <script src="script.js" defer></script>
-  <!-- <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile" defer></script> -->
-  <!-- <script src="turnstile.js" defer></script> -->
+  <!-- Step1 Turnstile導入 -->
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onLoadTurnstile" defer></script>
+  <script src="turnstile.js" defer></script>
   <!-- <script src="session.js" defer></script> -->
 </head>
 

--- a/public/turnstile.js
+++ b/public/turnstile.js
@@ -1,0 +1,40 @@
+const SITE_KEY = '0x4AAAAAAA1K1jrmgz4eYx4s';
+
+const translateBtn = document.getElementById('translate-btn');
+
+function onLoadTurnstile() {
+  translateBtn.disabled = true;
+  turnstile.render('#turnstile-widget', {
+    sitekey: SITE_KEY,
+    callback: onTurnstileSuccess,
+    'error-callback': onTurnstileError,
+    'expired-callback': onTurnstileExpired,
+  });
+}
+
+async function onTurnstileSuccess(token) {
+  const formData = new FormData();
+  formData.append('cf-turnstile-response', token);
+
+  const response = await fetch('/auth', {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (response.ok) {
+    translateBtn.disabled = false;
+  } else {
+    translateBtn.disabled = true;
+    alert('認証に失敗しました。再度お試しください。');
+  }
+}
+
+function onTurnstileError() {
+  translateBtn.disabled = true;
+  alert('Turnstileエラーが発生しました。再度お試しください。');
+}
+
+function onTurnstileExpired() {
+  translateBtn.disabled = true;
+  turnstile.reset();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import translate from './translate'
-// import turnstile from './turnstile'
+import turnstile from './turnstile'
 // import { sessionMiddleware } from './session'
 // import { csrfMiddleware, secFetchSiteMiddleware } from './csrf'
 
@@ -10,7 +10,7 @@ const app = new Hono()
 // app.use('*', secFetchSiteMiddleware())
 // app.use('/api/*', sessionMiddleware())
 
-// app.route('/auth', turnstile)
+app.route('/auth', turnstile)
 app.route('/api/translate', translate)
 
 export default app

--- a/src/turnstile.ts
+++ b/src/turnstile.ts
@@ -1,0 +1,48 @@
+import { Hono } from 'hono'
+// import { createSessionCookie } from './session'
+
+type ResponseJson = {
+  success: boolean
+}
+
+export async function verifyTurnstileToken(secretKey: string, token: string, ip: string | undefined) {
+  const formData = new FormData()
+  formData.set('secret', secretKey)
+  formData.set('response', token)
+  formData.set('remoteip', ip ?? '')
+  const response = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'POST',
+    body: formData,
+  })
+  const data: ResponseJson = await response.json()
+  if (!data.success) {
+    console.error(data)
+  }
+  return data.success
+}
+
+type Bindings = {
+  TURNSTILE_SECRET_KEY: string,
+  JWT_SECRET: string
+}
+
+const app = new Hono<{ Bindings: Bindings }>()
+
+app.post('/', async (c) => {
+  const secret = c.env.TURNSTILE_SECRET_KEY
+  const formData = await c.req.formData()
+  const token = formData.get('cf-turnstile-response')
+  const ip = c.req.header('CF-Connecting-IP')
+  if (!token || typeof token !== 'string') {
+    return c.text('Invalid input', 400)
+  }
+  const isValid = await verifyTurnstileToken(secret, token, ip);
+  if (!isValid) {
+    return c.text('Unauthenticated', 401)
+  }
+
+  // await createSessionCookie(c, { user: 'authenticated' }, c.env.JWT_SECRET)
+  return c.text('Authenticated')
+})
+
+export default app


### PR DESCRIPTION
- Re-enabled Turnstile scripts in `index.html` for client-side verification.
- Updated `index.ts` to include the Turnstile middleware and route `/auth`.

This commit marks the first step in enhancing the application's security by adding bot prevention measures using Cloudflare Turnstile.