### PR TITLE
Implement CSRF protection and update middleware configuration

### DIFF
--- a/src/csrf.ts
+++ b/src/csrf.ts
@@ -1,0 +1,27 @@
+import { createMiddleware } from "hono/factory"
+import { csrf } from "hono/csrf"
+import { HTTPException } from "hono/http-exception"
+
+type Bindings = {
+  ALLOWED_ORIGIN: string,
+}
+
+export const csrfMiddleware = () => createMiddleware<{ Bindings: Bindings }>(async (c, next) => {
+  const origin = c.env.ALLOWED_ORIGIN
+  if (!origin) {
+    throw new Error('環境変数 ALLOWED_ORIGIN が定義されていません。')
+  }
+  const csrfProtection = csrf({ origin })
+  await csrfProtection(c, next)
+})
+
+export const secFetchSiteMiddleware = () => createMiddleware(async (c, next) => {
+  const secFetchSite = c.req.header('Sec-Fetch-Site')
+  if (secFetchSite && secFetchSite !== 'same-origin') {
+    const res = new Response('Forbidden', {
+      status: 403,
+    })
+    throw new HTTPException(403, { res })
+  }
+  return next()
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,14 +4,19 @@ import translate from './translate'
 import turnstile from './turnstile'
 // Step2 JWTでセッションを管理
 import { sessionMiddleware } from './session'
-// import { csrfMiddleware, secFetchSiteMiddleware } from './csrf'
+// Step3 CSRF対策
+import { csrfMiddleware, secFetchSiteMiddleware } from './csrf'
 
 const app = new Hono()
 
-// app.use('*', csrfMiddleware())
-// app.use('*', secFetchSiteMiddleware())
+// Step3 CSRF対策
+app.use('*', csrfMiddleware())
+app.use('*', secFetchSiteMiddleware())
+
+// Step2 JWTでセッションを管理
 app.use('/api/*', sessionMiddleware())
 
+// Step1 Turnstileを導入
 app.route('/auth', turnstile)
 app.route('/api/translate', translate)
 


### PR DESCRIPTION
- Enabled `csrfMiddleware` and `secFetchSiteMiddleware` for CSRF protection in `index.ts`.
- Reorganized middleware to ensure proper sequencing:
  - Step 3: Added CSRF protection for all routes.
  - Step 2: Applied JWT session management for `/api/*` routes.
  - Step 1: Turnstile authentication remains for `/auth` route.