### PR TITLE
Refactor CSRF and Sec-Fetch-Site middleware for enhanced security

### DIFF
--- a/src/csrf.ts
+++ b/src/csrf.ts
@@ -7,21 +7,18 @@ type Bindings = {
 }
 
 export const csrfMiddleware = () => createMiddleware<{ Bindings: Bindings }>(async (c, next) => {
+  const secFetchSite = c.req.header('Sec-Fetch-Site')
+  if (secFetchSite && secFetchSite !== 'same-origin') {
+    console.error(`Sec-Fetch-Site が不正です: ${secFetchSite}`)
+    const res = new Response('Forbidden', {
+      status: 403,
+    })
+    throw new HTTPException(403, { res })
+  }
   const origin = c.env.ALLOWED_ORIGIN
   if (!origin) {
     throw new Error('環境変数 ALLOWED_ORIGIN が定義されていません。')
   }
   const csrfProtection = csrf({ origin })
   await csrfProtection(c, next)
-})
-
-export const secFetchSiteMiddleware = () => createMiddleware(async (c, next) => {
-  const secFetchSite = c.req.header('Sec-Fetch-Site')
-  if (secFetchSite && secFetchSite !== 'same-origin') {
-    const res = new Response('Forbidden', {
-      status: 403,
-    })
-    throw new HTTPException(403, { res })
-  }
-  return next()
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,12 @@ import turnstile from './turnstile'
 // Step2 JWTでセッションを管理
 import { sessionMiddleware } from './session'
 // Step3 CSRF対策
-import { csrfMiddleware, secFetchSiteMiddleware } from './csrf'
+import { csrfMiddleware } from './csrf'
 
 const app = new Hono()
 
 // Step3 CSRF対策
 app.use('*', csrfMiddleware())
-app.use('*', secFetchSiteMiddleware())
 
 // Step2 JWTでセッションを管理
 app.use('/api/*', sessionMiddleware())


### PR DESCRIPTION
- Merged Sec-Fetch-Site validation into `csrfMiddleware` in `csrf.ts`:
  - Consolidated logic to check `Sec-Fetch-Site` header and enforce same-origin requests.
  - Added error logging for invalid `Sec-Fetch-Site` values.
- Updated `index.ts` to use the streamlined `csrfMiddleware` without separate `secFetchSiteMiddleware`.
- Ensured environment variable `ALLOWED_ORIGIN` is validated during CSRF protection setup.
- Improved middleware readability and reduced redundant code.